### PR TITLE
fix:shared library cacheの更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,18 +35,21 @@ make install && \
 rm -rf  /temp/mecab_src/  && \
 rm -rf  /usr/src/mecab/
 
+# shared library cache を更新する
+RUN ldconfig
+
 # mecab-neologdのインストール用のdicディレクトリを作成
 RUN mkdir -p /usr/local/lib/mecab/dic
 
 # mecab-neologdのインストール
-RUN git clone https://github.com/neologd/mecab-ipadic-neologd.git /usr/src/mecab-ipadic-neologd && \
+RUN git clone http://github.com/neologd/mecab-ipadic-neologd.git /usr/src/mecab-ipadic-neologd && \
 /usr/src/mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -n -y && \
 rm -rf  /usr/src/mecab-ipadic-neologd && \
 pip3.6 install mecab-python3
 
 WORKDIR /
 # fasttextのインストール
-RUN git clone https://github.com/facebookresearch/fastText.git /tmp/fastText && \
+RUN git clone http://github.com/facebookresearch/fastText.git /tmp/fastText && \
   rm -rf /tmp/fastText/.git* && \
   mv /tmp/fastText/* / && \
   cd / && \


### PR DESCRIPTION
<img width="1338" alt="2018-08-24 14 29 31" src="https://user-images.githubusercontent.com/42016417/44566760-42b16100-a7aa-11e8-980c-b4f2198ddc22.png">
共有ファイルがあるはずなのに、ないと言われるので、毎ビルド時にcacheの更新を行うように、
修正
cf : http://kaworu.jpn.org/kaworu/2011-12-08-1.php